### PR TITLE
fix: 매수/매도 API 수정

### DIFF
--- a/eta/src/main/java/com/example/eta/controller/PortfolioController.java
+++ b/eta/src/main/java/com/example/eta/controller/PortfolioController.java
@@ -69,7 +69,7 @@ public class PortfolioController {
     }
 
     @PostMapping("/{port_id}/sell")
-    public ResponseEntity<Void> sellStock(@PathVariable("port_id") Integer pfId, @RequestBody PortfolioDto.sellRequestDto sellRequestDto) {
+    public ResponseEntity<Void> sellStock(@PathVariable("port_id") Integer pfId, @RequestBody PortfolioDto.SellRequestDto sellRequestDto) {
         portfolioService.sellStock(pfId, sellRequestDto);
         return ResponseEntity.ok().build();
     }

--- a/eta/src/main/java/com/example/eta/dto/PortfolioDto.java
+++ b/eta/src/main/java/com/example/eta/dto/PortfolioDto.java
@@ -23,6 +23,7 @@ public class PortfolioDto {
     }
 
     @Data
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BuyRequestDto {
@@ -80,7 +81,7 @@ public class PortfolioDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class sellRequestDto {
+    public static class SellRequestDto {
         private String ticker;
         private Boolean isBuy;
         private int quantity;


### PR DESCRIPTION
매수 API에서 이미 보유한 종목 업데이트 시에도 비중 조정하도록 수정
매도 API에서 portfolioTicker 삭제 시 양방향 매핑을 고려해서 portfolio.portfolioTickers에서 portfolioTicker 삭제하도록 수정 리펙토링, 테스트 코드 추가